### PR TITLE
KeyboardInterrupt and classifiers

### DIFF
--- a/party_parrot/party.py
+++ b/party_parrot/party.py
@@ -46,7 +46,11 @@ def main(screen):
 
 
 def party():
-    Screen.wrapper(main)
+    try:
+        Screen.wrapper(main)
+    except KeyboardInterrupt:
+        pass
+
 
 if __name__ == '__main__':
     party()

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ setuptools.setup(
     install_requires=[
         "asciimatics==1.9.0",
     ],
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ),
+    ],
 )


### PR DESCRIPTION
Saw this from Pipenv, awesome project :)

When I tried this out I instinctively pressed ctrl-c to end the party (okey sorry I admit I didn’t read the docs first) and was surprised by a traceback. Turns out ASCIIMatics does not handle it by default. This fixed that.

Also pip told me this

```
Warning: 'classifiers' should be a list, got type 'tuple'
```

So I also fixed that.